### PR TITLE
fix routes, use HTTP method instead of match

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 OtaEnroll::Engine.routes.draw do
-  match "/ca" => "profile#ca"
-  match "/enroll" => "profile#enroll"
-  match "/profile" => "profile#profile"
-  match "/scep" => "profile#scep"
+  get "/ca" => "profile#ca"
+  get "/enroll" => "profile#enroll"
+  post "/profile" => "profile#profile"
+  get "/scep" => "profile#scep"
 end


### PR DESCRIPTION
Fix the route error when the server is starting on rails 4

``` ruby
/home/vagrant/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/actionpack-4.0.4/lib/action_dispatch/routing/mapper.rb:191:in `normalize_conditions!': You should not use the `match` method in your router without specifying an HTTP method. (RuntimeError)
If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.
If you want to expose your action to GET, use `get` in the router:
  Instead of: match "controller#action"
  Do: get "controller#action"
```
